### PR TITLE
Fix script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ssh toolhubuser@<NAS-IP> -p 22
 
 ### Predefined Scripts
 
-- `/scripts/split-audio.sh input.m4a audio/out/jobname`  
+- `/scripts/audio-split.sh input.m4a audio/out/jobname`
 - Add additional scripts to `/volume1/docker/toolhub/scripts`.
 
 ### Webhook API
@@ -172,7 +172,7 @@ ssh toolhubuser@<NAS-IP> -p 22
   # Daily audio-split at 03:00
   0 3 * * * toolhubuser cd /shared && \
     for f in audio/in/*.m4a; do \
-      [ -f "$f" ] && /scripts/split-audio.sh "$f" "audio/out/$(basename "$f" .m4a)"; \
+      [ -f "$f" ] && /scripts/audio-split.sh "$f" "audio/out/$(basename "$f" .m4a)"; \
     done
   ```
 
@@ -188,7 +188,7 @@ ssh toolhubuser@<NAS-IP> -p 22
 ├── conf/
 │   └── .env
 ├── scripts/
-│   ├── split-audio.sh
+│   ├── audio-split.sh
 │   └── webhook.py
 ├── cron.d/
 │   └── split-audio

--- a/cron.d/audio-split
+++ b/cron.d/audio-split
@@ -5,5 +5,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 0 3 * * * toolhubuser cd /shared && \
   for f in audio/in/*.m4a; do \
     [ -f "$f" ] && job=$(basename "$f" .m4a) && \
-    /scripts/split-audio.sh "$f" "audio/out/$job"; \
+    /scripts/audio-split.sh "$f" "audio/out/$job"; \
   done


### PR DESCRIPTION
## Summary
- update README references to use `audio-split.sh`
- update cron file to call `audio-split.sh`

## Testing
- `grep -R "split-audio.sh" -n`


------
https://chatgpt.com/codex/tasks/task_e_687755eb54d0832f9f2700e618e3dbcc