### PR TITLE
Add dependency checks to audio split

### DIFF
--- a/docs/audio-split.md
+++ b/docs/audio-split.md
@@ -2,6 +2,8 @@
 
 `scripts/audio-split.sh` splits an audio file into fixed-size chunks or at points of silence.
 
+**Dependencies:** `ffmpeg`, `ffprobe`, and `bc` must be available in the PATH.
+
 ## Syntax
 
 ```bash

--- a/scripts/audio-split.sh
+++ b/scripts/audio-split.sh
@@ -11,6 +11,13 @@ set -x
 # Trap errors: log any failed command with timestamp, line number and exit status
 trap 'echo "[$(date)] ERROR in $0 at line $LINENO: \"$BASH_COMMAND\" exited with status $?." >> "$LOGFILE"' ERR
 echo "==== $(date) ===="
+# Verify required tools are available before continuing
+for cmd in ffmpeg ffprobe bc; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command '$cmd' not found" >&2
+    exit 1
+  fi
+done
 # audio-split.sh - Split audio files in fixed or silence-based chunks
 # Usage:
 #   ./audio-split.sh --mode fixed|silence --chunk-length <seconds> --input <file> [--output <dir>] [--silence-seek <seconds>] [--silence-duration <seconds>] [--silence-threshold <dB>] [--padding <seconds>] [--enhance] [--enhance-speech]


### PR DESCRIPTION
## Summary
- add explicit dependency checks for ffmpeg, ffprobe and bc in audio-split.sh
- document required dependencies in audio-split docs

## Testing
- `python3 -m py_compile scripts/webhook.py`
- `bash -n scripts/audio-split.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a0ecd8fe0832f9e38d70faac6547d