### PR TITLE
Improve error handling and log reporting

### DIFF
--- a/docs/audio-split.md
+++ b/docs/audio-split.md
@@ -2,6 +2,8 @@
 
 `scripts/audio-split.sh` splits an audio file into fixed-size chunks or at points of silence.
 
+**Dependencies:** `ffmpeg`, `ffprobe`, and `bc` must be available in the PATH.
+
 ## Syntax
 
 ```bash

--- a/scripts/audio-split.sh
+++ b/scripts/audio-split.sh
@@ -11,6 +11,13 @@ set -x
 # Trap errors: log any failed command with timestamp, line number and exit status
 trap 'echo "[$(date)] ERROR in $0 at line $LINENO: \"$BASH_COMMAND\" exited with status $?." >> "$LOGFILE"' ERR
 echo "==== $(date) ===="
+# Verify required tools are available before continuing
+for cmd in ffmpeg ffprobe bc; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command '$cmd' not found" >&2
+    exit 1
+  fi
+done
 # audio-split.sh - Split audio files in fixed or silence-based chunks
 # Usage:
 #   ./audio-split.sh --mode fixed|silence --chunk-length <seconds> --input <file> [--output <dir>] [--silence-seek <seconds>] [--silence-duration <seconds>] [--silence-threshold <dB>] [--padding <seconds>] [--enhance] [--enhance-speech]

--- a/scripts/webhook.py
+++ b/scripts/webhook.py
@@ -214,7 +214,18 @@ def audio_split():
         logger.exception("Error running split script")
         logger.error(f"STDOUT: {e.stdout}")
         logger.error(f"STDERR: {e.stderr}")
-        return jsonify({"error": str(e), "stdout": e.stdout, "stderr": e.stderr}), 500
+        log_tail = ""
+        try:
+            with open("/logs/audio-split.log", "r") as log_f:
+                log_tail = "".join(log_f.readlines()[-20:])
+        except Exception as log_err:
+            log_tail = f"Failed to read log: {log_err}"
+        return jsonify({
+            "error": str(e),
+            "stdout": e.stdout,
+            "stderr": e.stderr,
+            "log_tail": log_tail,
+        }), 500
 
     zip_path = f"/shared/audio/out/{job_id}.zip"
     logger.info(f"Zipping output directory {output_dir} into {zip_path}")


### PR DESCRIPTION
## Summary
- return tail of split log when audio split script fails
- ensure newline at end of `audio-split.sh`

## Testing
- `python3 -m py_compile scripts/webhook.py`
- `bash -n scripts/audio-split.sh`


------
https://chatgpt.com/codex/tasks/task_e_687a0ecd8fe0832f9e38d70faac6547d